### PR TITLE
fix: make migration 010 enum creation idempotent

### DIFF
--- a/database/migrations/versions/010_add_csv_import_tables.py
+++ b/database/migrations/versions/010_add_csv_import_tables.py
@@ -17,8 +17,14 @@ depends_on = None
 
 
 def upgrade():
-    # Create import status enum
-    op.execute("CREATE TYPE importstatus AS ENUM ('pending', 'processing', 'completed', 'failed', 'cancelled')")
+    # Create import status enum (idempotent - safe to run multiple times)
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE importstatus AS ENUM ('pending', 'processing', 'completed', 'failed', 'cancelled');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
     
     # Create import_batches table
     op.create_table('import_batches',


### PR DESCRIPTION
## Summary

Fixes database migration enum conflict blocking CI/CD pipeline.

**Problem**: Migration 010 creates `importstatus` enum without checking if it already exists, causing `psycopg2.errors.DuplicateObject` errors in CI/CD.

**Solution**: Wrapped `CREATE TYPE` statement in PostgreSQL's idempotent pattern using `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null; END $$;`

## Changes

- Modified `/database/migrations/versions/010_add_csv_import_tables.py`
- Enum creation now idempotent (safe to run multiple times)
- No schema changes if enum already exists

## Testing

- Tested locally against existing database with enum present
- SQL executes successfully without errors
- Verified downgrade logic still uses `DROP TYPE IF EXISTS` (already idempotent)

## Impact

- **Safe to merge**: No-op if enum already exists in database
- **Unblocks CI/CD**: Fixes Database Migration Test workflow
- **Enables Auth0 PR**: Unblocks PR #46 Zebra smoke tests

## Fixes

- Database Migration Test workflow failure
- Zebra smoke test pipeline blockage

🤖 Generated with [Claude Code](https://claude.com/claude-code)